### PR TITLE
Fix found by DorisP.

### DIFF
--- a/src/android/Cache.java
+++ b/src/android/Cache.java
@@ -264,7 +264,7 @@ public class Cache extends CordovaPlugin {
         File newFile;
         do {
             newFileName = (cachedMediaCounter++) + extension;
-            newFile = new File(newFileName);
+            newFile = new File(cachedMediaDirectory, newFileName);
         } while(newFile.exists());
         
         //return filename with same extension as url


### PR DESCRIPTION
Corrects pulling the cache file from the wrong location because of missing directory path in File constructor.
#2
